### PR TITLE
scriptタグにdefer属性をつけて</body>直前から<head>内に移動した

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,20 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html>
+<html lang="ja">
 <head>
     <title>Ohara Git User Group</title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link rel="stylesheet" href="assets/css/main.css"/>
+
+    <!-- Scripts -->
+    <script src="assets/js/jquery.min.js" defer></script>
+    <script src="assets/js/jquery.scrollzer.min.js" defer></script>
+    <script src="assets/js/jquery.scrolly.min.js" defer></script>
+    <script src="assets/js/skel.min.js" defer></script>
+    <script src="assets/js/util.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
 </head>
 <body>
 
@@ -49,9 +57,9 @@
         <!-- Two -->
         <section id="two">
             <div class="container">
-                <h2>第２回Git勉強会</h2>
+                <h2>第2回Git勉強会</h2>
                 <div class="features">
-                    <p>第２回Git勉強会を開催します。みなさま、是非ご参加ください！</p>
+                    <p>第2回Git勉強会を開催します。みなさま、是非ご参加ください!</p>
                     <article>
                         <h3>イベント日時・場所</h3>
                         <p>3月23日 19:00開始</p>
@@ -121,7 +129,7 @@
         <section id="three">
             <div class="container">
                 <h2>過去のイベント</h2>
-                <h3>第１回Git勉強会</h3>
+                <h3>第1回Git勉強会</h3>
                 <div class="features">
                     <article>
                         <h4>Gitはじめの一歩 (@ihcomegaさん)</h4>
@@ -149,14 +157,6 @@
     </section>
 
 </div>
-
-<!-- Scripts -->
-<script src="assets/js/jquery.min.js"></script>
-<script src="assets/js/jquery.scrollzer.min.js"></script>
-<script src="assets/js/jquery.scrolly.min.js"></script>
-<script src="assets/js/skel.min.js"></script>
-<script src="assets/js/util.js"></script>
-<script src="assets/js/main.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
###変更内容
scriptタグにdefer属性をつけて</body>直前から<head>内に移動しました。
###背景
現在、scriptタグを</body>直前に記述していますが、defer属性をつけることで、JSの読み取りをHTML解析と同時に並行して行ってくれることが判明しましたので、scriptタグにdefer属性をつけました。これにより、わざわざHTMLの最後に書いてHTMLの読み込みが終わってからJSの読み込みを開始させる意味が無くなりましたので、scriptタグを<head>内に移動しました。

